### PR TITLE
feat: update chat UI with new style design, responsive layout and perform rendering

### DIFF
--- a/examples/demo/src/ChatScreen.tsx
+++ b/examples/demo/src/ChatScreen.tsx
@@ -56,9 +56,6 @@ export default function ChatScreen({ currentUser }: Props) {
               conversationId={activeConversation}
               currentUserId={currentUser.id}
               memberIds={[currentUser.id, recipientId.trim()]}
-              onLogout={() => {
-                setActiveConversation(null);
-              }}
             />
           </ChatProvider>
         </div>

--- a/examples/demo/src/ChatScreen.tsx
+++ b/examples/demo/src/ChatScreen.tsx
@@ -56,6 +56,9 @@ export default function ChatScreen({ currentUser }: Props) {
               conversationId={activeConversation}
               currentUserId={currentUser.id}
               memberIds={[currentUser.id, recipientId.trim()]}
+              onLogout={() => {
+                setActiveConversation(null);
+              }}
             />
           </ChatProvider>
         </div>

--- a/examples/demo/src/main.tsx
+++ b/examples/demo/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import '@saigontechnology/react-firebase-chat/styles';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/examples/demo/vite.config.ts
+++ b/examples/demo/vite.config.ts
@@ -6,8 +6,22 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     dedupe: ['firebase', 'react', 'react-dom'],
-    alias: {
-      'firebase': path.resolve(__dirname, 'node_modules/firebase'),
-    },
+    alias: [
+      {
+        find: 'firebase',
+        replacement: path.resolve(__dirname, 'node_modules/firebase'),
+      },
+      // CSS sub-path — resolved from the built dist so Tailwind is pre-compiled
+      {
+        find: /^@saigontechnology\/react-firebase-chat\/styles$/,
+        replacement: path.resolve(__dirname, '../../dist/styles.css'),
+      },
+      // JS/TS entry — resolved from source so edits are reflected instantly
+      // without needing to rebuild the library or re-run npm install.
+      {
+        find: /^@saigontechnology\/react-firebase-chat$/,
+        replacement: path.resolve(__dirname, '../../src/index.ts'),
+      },
+    ],
   },
 });

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,30 +1,45 @@
 import React from 'react';
+import { IUser } from '../types';
 import { UserAvatar } from './UserAvatar';
+import { ButtonMaterialIcon } from './ButtonMaterialIcon';
 
 export interface ChatHeaderProps {
-  currentUser: { id: string | number; name?: string; avatar?: string } | null;
-  onLogout?: () => void;
-  rightExtras?: React.ReactNode;
+  /** Display name of the conversation / partner */
+  name: string;
+  /** Partner user — shows avatar when provided */
+  partner?: IUser | null;
+  /** Called when the back arrow is tapped (mobile) */
+  onBack?: () => void;
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({ currentUser, onLogout: _onLogout, rightExtras }) => {
+export const ChatHeader: React.FC<ChatHeaderProps> = ({ name, partner, onBack }) => {
   return (
-    <div className="app-header">
-      <div className="header-left" />
-      <div className="header-center">
-        {/* Logo placeholder */}
-      </div>
-      <div className="header-right">
-        <div className="profile">
-          <UserAvatar user={currentUser as any} />
-          <span className="profile-name">{currentUser?.name || 'Me'}</span>
+    <div className="chat-panel-header">
+      <div className="chat-target">
+        <button
+          className="chat-back-btn"
+          onClick={onBack}
+          aria-label="Back to conversations"
+        >
+          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        {partner && <UserAvatar user={partner} size="small" />}
+
+        <div className="chat-target-info">
+          <span className="target-name">{name}</span>
+          <span className="target-status">Active now</span>
         </div>
-        {rightExtras}
+      </div>
+
+      <div className="chat-actions">
+        <ButtonMaterialIcon className="icon-btn" title="Voice call" icon="call" />
+        <ButtonMaterialIcon className="icon-btn" title="Video call" icon="videocam" />
       </div>
     </div>
   );
 };
 
 export default ChatHeader;
-
-

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useRef, useEffect } from "react";
 import { format, isToday, isYesterday } from "date-fns";
 import { UserAvatar } from "./UserAvatar";
 import { ConversationProps } from "../types";
@@ -25,6 +25,8 @@ export interface ChatListProps {
   searchPlaceholder?: string;
   /** Debounce delay in ms (default: 300) */
   searchDebounceDelay?: number;
+  /** Called when the user taps Logout in the avatar menu */
+  onLogout?: () => void;
 }
 
 export const ChatList: React.FC<ChatListProps> = ({
@@ -32,13 +34,28 @@ export const ChatList: React.FC<ChatListProps> = ({
   conversations,
   selectedConversationId,
   handleSelectConversation,
-  hasSearchBar = false,
+  hasSearchBar = true,
   searchPlaceholder = "Search conversations...",
   searchDebounceDelay = 300,
+  onLogout,
 }) => {
   const { currentUser } = useChatContext();
   const [searchText, setSearchText] = useState("");
   const debouncedSearch = useDebounce(searchText, searchDebounceDelay);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close the menu when clicking outside
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [menuOpen]);
 
   const filteredConversations = useMemo(() => {
     if (!debouncedSearch.trim()) return conversations;
@@ -53,53 +70,80 @@ export const ChatList: React.FC<ChatListProps> = ({
   return (
     <aside className="sidebar">
       <div className="sidebar-header">
-        <h4>Chat</h4>
-        <button className="new-btn" onClick={openNewChatFunc}>
-          New
-        </button>
-      </div>
-      {hasSearchBar && (
-        <div className="search-bar-container" style={{ padding: "0 12px 8px" }}>
-          <div style={{ position: "relative" }}>
-            <input
-              type="text"
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-              placeholder={searchPlaceholder}
-              className="search-bar-input"
-              style={{
-                width: "100%",
-                padding: "8px 32px 8px 12px",
-                borderRadius: "8px",
-                border: "1px solid #e5e7eb",
-                fontSize: "14px",
-                outline: "none",
-                backgroundColor: "#f9fafb",
-              }}
-            />
-            {searchText && (
+        <div className="sidebar-title-row">
+          {/* Current user avatar — left slot, opens profile menu */}
+          {currentUser && (
+            <div className="avatar-menu-anchor" ref={menuRef}>
               <button
-                onClick={() => setSearchText("")}
-                style={{
-                  position: "absolute",
-                  right: "8px",
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                  color: "#9ca3af",
-                  fontSize: "16px",
-                  padding: "0 4px",
-                  lineHeight: "1",
-                }}
+                className="avatar-menu-trigger"
+                onClick={() => setMenuOpen((o) => !o)}
+                aria-label="Profile menu"
+                aria-expanded={menuOpen}
               >
-                &times;
+                <UserAvatar
+                  user={{ id: String(currentUser.id), name: currentUser.name, avatar: currentUser.avatar }}
+                  size="small"
+                />
               </button>
-            )}
-          </div>
+
+              {menuOpen && (
+                <div className="avatar-menu-popup">
+                  <div className="avatar-menu-user">
+                    <UserAvatar
+                      user={{ id: String(currentUser.id), name: currentUser.name, avatar: currentUser.avatar }}
+                      size="medium"
+                    />
+                    <div className="avatar-menu-user-info">
+                      <span className="avatar-menu-name">{currentUser.name || "Me"}</span>
+                    </div>
+                  </div>
+                  <div className="avatar-menu-divider" />
+                  {onLogout && (
+                    <button
+                      className="avatar-menu-item avatar-menu-item--danger"
+                      onClick={() => { setMenuOpen(false); onLogout(); }}
+                    >
+                      <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                      </svg>
+                      Log out
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          <h2 className="sidebar-title">Messages</h2>
+
+          {/* Compose icon — right slot (new chat) */}
+          <button className="sidebar-icon-btn" onClick={openNewChatFunc} aria-label="New conversation">
+            <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
         </div>
-      )}
+
+        {hasSearchBar && <div className="search-bar-wrapper">
+          <svg className="search-icon" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="text"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            placeholder={searchPlaceholder}
+          />
+          {searchText && (
+            <button
+              onClick={() => setSearchText("")}
+              style={{ background: "none", border: "none", cursor: "pointer", color: "#9ca3af", fontSize: "16px", padding: "0", lineHeight: "1" }}
+            >
+              &times;
+            </button>
+          )}
+        </div>}
+      </div>
       <div className="conversation-list">
         {filteredConversations.map((c) => (
           <button
@@ -119,6 +163,7 @@ export const ChatList: React.FC<ChatListProps> = ({
                     (c.members ?? []).find((m: string) => m !== currentUser?.id) || "",
                   avatar: c.image,
                 }}
+                size="medium"
               />
             </div>
             <div className="conversation-meta">
@@ -126,16 +171,18 @@ export const ChatList: React.FC<ChatListProps> = ({
                 <span className="conversation-name">{c.name || "Unknown"}</span>
                 <span className="conversation-time">{formatConversationTime(c.updatedAt)}</span>
               </div>
-              <div className="conversation-last">
-                {c?.latestMessage?.text || ""}
+              <div className="conversation-bottom">
+                <span className="conversation-last">
+                  {c?.latestMessage?.text || ""}
+                </span>
+                {(c.unRead || 0) > 0 && (
+                  <span className="unread-badge">{c.unRead || 0}</span>
+                )}
               </div>
             </div>
-            {(c.unRead || 0) > 0 && (
-              <span className="unread-badge">{c.unRead || 0}</span>
-            )}
           </button>
         ))}
-        {hasSearchBar && debouncedSearch && filteredConversations.length === 0 && (
+        {debouncedSearch && filteredConversations.length === 0 && (
           <div style={{ padding: "16px", textAlign: "center", color: "#9ca3af", fontSize: "14px" }}>
             No conversations found
           </div>

--- a/src/components/ChatScreen.css
+++ b/src/components/ChatScreen.css
@@ -25,8 +25,8 @@
   max-width: 100%;
   box-sizing: border-box;
   overflow-x: hidden;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
   background: #ffffff;
   height: 100%;
 }
@@ -37,8 +37,9 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 16px;
-  background: #1e88e5;
-  color: #fff;
+  background: #ffffff;
+  color: #111827;
+  border-bottom: 1px solid #e5e7eb;
 }
 
 .header-center {
@@ -67,14 +68,16 @@
 
 .profile-name {
   font-weight: 600;
+  color: #111827;
 }
 
 .logout-btn {
   padding: 6px 10px;
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  color: #fff;
+  border: 1px solid #e5e7eb;
+  color: #374151;
   cursor: pointer;
+  background: transparent;
 }
 
 /* Main Content layout */
@@ -88,8 +91,8 @@
 
 /* Sidebar */
 .sidebar {
-  border-right: 1px solid #e0e0e0;
-  background: #f7f9fc;
+  border-right: 1px solid #e5e7eb;
+  background: #ffffff;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -98,67 +101,211 @@
 
 .sidebar-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
+  flex-direction: column;
+  padding: 16px;
+  border-bottom: 1px solid #e5e7eb;
+  gap: 12px;
 }
 
-.new-btn {
-  background: #e3f2fd;
-  color: #1e88e5;
+.sidebar-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* ── Avatar menu ─────────────────────────────────────────────────────────── */
+
+.avatar-menu-anchor {
+  position: relative;
+}
+
+.avatar-menu-trigger {
+  background: transparent;
   border: none;
-  border-radius: 6px;
-  padding: 6px 10px;
   cursor: pointer;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatar-menu-trigger:hover {
+  opacity: 0.85;
+}
+
+.avatar-menu-popup {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 100;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  min-width: 200px;
+  overflow: hidden;
+  animation: menuFadeIn 0.15s ease;
+}
+
+@keyframes menuFadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.avatar-menu-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+}
+
+.avatar-menu-user-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.avatar-menu-name {
   font-weight: 600;
+  font-size: 14px;
+  color: #111827;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.avatar-menu-divider {
+  height: 1px;
+  background: #e5e7eb;
+  margin: 0;
+}
+
+.avatar-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #374151;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.avatar-menu-item:hover {
+  background: #f9fafb;
+}
+
+.avatar-menu-item--danger {
+  color: #ef4444;
+}
+
+.avatar-menu-item--danger:hover {
+  background: #fef2f2;
+}
+
+.sidebar-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #111827;
+  flex: 1;
+  text-align: center;
+}
+
+.sidebar-icon-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #374151;
+  padding: 4px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease;
+}
+
+.sidebar-icon-btn:hover {
+  background: #f3f4f6;
+}
+
+.search-bar-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f3f4f6;
+  border-radius: 10px;
+  padding: 8px 12px;
+}
+
+.search-bar-wrapper input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  color: #111827;
+}
+
+.search-bar-wrapper input::placeholder {
+  color: #9ca3af;
+}
+
+.search-icon {
+  color: #9ca3af;
+  flex-shrink: 0;
 }
 
 .conversation-list {
   flex: 1;
   overflow-y: auto;
-  padding: 8px;
+  padding: 0;
 }
 
 .conversation-item {
   display: flex;
   width: 100%;
-  gap: 10px;
-  padding: 10px;
-  border-radius: 10px;
+  gap: 12px;
+  padding: 12px 16px;
   border: none;
-  background: #fff;
+  background: transparent;
   cursor: pointer;
   text-align: left;
+  align-items: center;
+  transition: background 0.15s ease;
 }
 
-.conversation-item+.conversation-item {
-  margin-top: 8px;
+.conversation-item:hover {
+  background: #f9fafb;
 }
 
 .conversation-item.active {
-  outline: 2px solid #1e88e5;
-  background: #eef6ff;
+  background: #eff6ff;
 }
 
 .conversation-avatar {
   position: relative;
-  width: 2rem;
-  min-width: 2rem;
-  height: 2rem;
-  border-radius: 50%;
-  background: #cfd8dc;
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
 }
 
 .unread-badge {
-  background: #1e88e5;
+  background: #3b82f6;
   color: #fff;
   font-size: 11px;
-  width: 20px;
+  min-width: 20px;
   height: 20px;
   border-radius: 999px;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0 5px;
+  flex-shrink: 0;
 }
 
 .conversation-meta {
@@ -166,6 +313,7 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  gap: 2px;
 }
 
 .conversation-top {
@@ -177,18 +325,11 @@
 
 .conversation-name {
   font-weight: 600;
-  color: #1f2937;
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #9ca3af;
-}
-
-.status-dot.online {
-  background: #22c55e;
+  color: #111827;
+  font-size: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .conversation-time {
@@ -198,12 +339,20 @@
   flex-shrink: 0;
 }
 
+.conversation-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .conversation-last {
   color: #6b7280;
-  font-size: 12px;
+  font-size: 13px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
 }
 
 /* Chat panel */
@@ -220,7 +369,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
 }
 
 .chat-target {
@@ -229,49 +379,75 @@
   gap: 10px;
 }
 
+.chat-target-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
 .target-name {
-  font-weight: 700;
+  font-weight: 600;
+  font-size: 15px;
+  color: #111827;
 }
 
 .target-status {
-  color: #22c55e;
+  color: #6b7280;
   font-size: 12px;
 }
 
 .chat-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
 }
 
 .icon-btn {
-  background: #eef2f7;
+  background: transparent;
   border: none;
   border-radius: 8px;
   padding: 8px;
   cursor: pointer;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease;
+}
+
+.icon-btn:hover {
+  background: #f3f4f6;
 }
 
 /* Input panel */
 .panel-input {
-  padding: 16px;
-  border-top: 1px solid #e0e0e0;
+  padding: 12px 16px;
+  border-top: 1px solid #e5e7eb;
+  background: #ffffff;
 }
 
 .input-box {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 8px;
-  background: #fff;
 }
 
 .attach-btn {
   width: 36px;
   height: 36px;
-  border-radius: 8px;
-  background: #eef2f7;
+  border-radius: 50%;
+  background: transparent;
   border: none;
   cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.attach-btn:hover {
+  background: #f3f4f6;
 }
 
 .input-flex {
@@ -279,13 +455,19 @@
   display: flex;
 }
 
+.message-input-reset {
+  background: transparent !important;
+}
+
 .message-input-reset>div>textarea {
   border: none !important;
   box-shadow: none !important;
+  background: transparent !important;
 }
 
 .message-input-reset>div {
   width: 100%;
+  background: transparent !important;
 }
 
 /* keep send button visible */
@@ -388,9 +570,8 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  overflow-y: auto;
   min-width: 0;
-  background: #fafafa;
+  background: #ffffff;
 }
 
 /* Panel-specific loading */
@@ -550,65 +731,125 @@
   outline: none;
 }
 
-/* Responsive Styles */
-@media (max-width: 768px) {
+/* Empty chat panel state */
+.chat-panel-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #9ca3af;
+  padding: 40px;
+}
+
+.chat-panel-empty-icon {
+  opacity: 0.4;
+}
+
+.chat-panel-empty-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #6b7280;
+  margin: 0;
+}
+
+.chat-panel-empty-subtitle {
+  font-size: 14px;
+  color: #9ca3af;
+  text-align: center;
+  margin: 0;
+  max-width: 260px;
+}
+
+/* Back button — visible only on mobile */
+.chat-back-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #3b82f6;
+  padding: 4px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.chat-back-btn:hover {
+  background: #f3f4f6;
+}
+
+/* ──────────────────────────────────────────────
+   Responsive — Desktop (≥ 768px): side-by-side
+   ────────────────────────────────────────────── */
+@media (min-width: 768px) {
+  .main-content {
+    grid-template-columns: 320px 1fr;
+  }
+
+  /* Always show both panels */
+  .sidebar {
+    display: flex !important;
+  }
+
+  .chat-panel {
+    display: flex !important;
+  }
+
+  .chat-back-btn {
+    display: none !important;
+  }
+}
+
+/* ──────────────────────────────────────────────
+   Responsive — Mobile (< 768px): single panel
+   ────────────────────────────────────────────── */
+@media (max-width: 767px) {
   .chat-screen {
     border: none;
     border-radius: 0;
-    width: 100%;
   }
 
-  .chat-header {
-    padding: 12px 16px;
+  .app-header {
+    display: none; /* global header hidden on mobile — panel header takes over */
   }
 
-  .partner-name {
-    font-size: 14px;
+  .main-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    grid-template-columns: unset;
   }
 
-  .partner-avatar {
-    width: 28px;
-    height: 28px;
+  /* Default: show sidebar, hide chat panel */
+  .sidebar {
+    display: flex;
+    flex: 1;
+    border-right: none;
   }
 
-  .input-container {
-    padding: 12px 16px;
-    gap: 6px;
+  .chat-panel {
+    display: none;
   }
 
-  .action-button {
-    width: 36px;
-    height: 36px;
-    font-size: 16px;
+  /* When a conversation is selected: hide sidebar, show chat panel */
+  .main-content.has-conversation .sidebar {
+    display: none;
   }
 
-  .gallery-container {
-    padding: 12px 16px;
-    max-height: 150px;
+  .main-content.has-conversation .chat-panel {
+    display: flex;
+    flex: 1;
+  }
+
+  /* Show back button on mobile */
+  .chat-back-btn {
+    display: flex;
   }
 
   .uploader-content {
     width: 95%;
     padding: 16px;
-  }
-}
-
-@media (max-width: 480px) {
-  .chat-header {
-    padding: 8px 12px;
-  }
-
-  .input-container {
-    padding: 8px 12px;
-  }
-
-  .action-buttons {
-    gap: 4px;
-  }
-
-  .action-button {
-    width: 32px;
-    height: 32px;
-    font-size: 14px;
   }
 }

--- a/src/components/ChatScreen.tsx
+++ b/src/components/ChatScreen.tsx
@@ -101,7 +101,7 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
   onLoadEnd,
   sendMessageNotification,
   timeoutSendNotify = DEFAULT_CLEAR_SEND_NOTIFICATION,
-  hasSearchBar = false,
+  hasSearchBar = true,
   searchPlaceholder,
   searchDebounceDelay,
 }) => {
@@ -411,11 +411,9 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
 
   return (
     <div className={`chat-screen ${className}`} style={style}>
-      {/* App Header */}
-      {renderHeader ? renderHeader() : <ChatHeader currentUser={currentUser} />}
 
       {/* Main Content */}
-      <div className="main-content">
+      <div className={`main-content${selectedConversationId ? " has-conversation" : ""}`}>
         {/* Sidebar - Conversations */}
         {renderChatList ? (
           renderChatList({
@@ -441,98 +439,103 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
 
         {/* Chat Panel */}
         <section className="chat-panel">
-          <div className="chat-panel-header">
-            <div className="chat-target">
-              <span className="target-name">
-                {customConversationInfo?.name ||
+          {!selectedConversationId ? (
+            <div className="chat-panel-empty">
+              <div className="chat-panel-empty-icon">
+                <svg width="64" height="64" fill="none" viewBox="0 0 24 24" stroke="#d1d5db">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                </svg>
+              </div>
+              <p className="chat-panel-empty-title">Select a conversation</p>
+              <p className="chat-panel-empty-subtitle">Choose a conversation from the list to start messaging</p>
+            </div>
+          ) : (
+            <>
+              {/* App Header */}
+              { renderHeader ? renderHeader() :
+                <ChatHeader
+                name={
+                  customConversationInfo?.name ||
                   selectedName ||
                   selectedPartners[0]?.name ||
-                  "..."}
-              </span>
-            </div>
-            <div className="chat-actions">
-              <ButtonMaterialIcon
-                className="icon-btn"
-                title="Voice call"
-                icon="call"
-              />
-              <ButtonMaterialIcon
-                className="icon-btn"
-                title="Video call"
-                icon="videocam"
-              />
-            </div>
-          </div>
+                  "..."
+                }
+                partner={selectedPartners[0] ?? null}
+                onBack={() => setSelectedConversationId(undefined)}
+              />}
 
-          <div className="messages-container">
-            {loading ? (
-              <div className="panel-loading">
-                <div className="spinner" />
+              <div className="messages-container">
+                {loading ? (
+                  <div className="panel-loading">
+                    <div className="spinner" />
+                  </div>
+                ) : (
+                  <>
+                    <MessageList
+                      messages={messages}
+                      currentUser={convertedUser}
+                      partnerUsers={selectedPartners}
+                      onMessageUpdate={(message) =>
+                        console.log("Message updated:", message)
+                      }
+                      onMessageDelete={(messageId) =>
+                        console.log("Delete message:", messageId)
+                      }
+                      messageStatusEnable={messageStatusEnable}
+                      customMessageStatus={customMessageStatus}
+                      unReadSentMessage={unReadSentMessage}
+                      unReadSeenMessage={unReadSeenMessage}
+                      maxPageSize={maxPageSize}
+                    />
+                    {enableTyping && <TypingIndicator typingUsers={typingUsers} />}
+                  </>
+                )}
               </div>
-            ) : (
-              <>
-                <MessageList
-                  messages={messages}
-                  currentUser={convertedUser}
-                  partnerUsers={selectedPartners}
-                  onMessageUpdate={(message) =>
-                    console.log("Message updated:", message)
-                  }
-                  onMessageDelete={(messageId) =>
-                    console.log("Delete message:", messageId)
-                  }
-                  messageStatusEnable={messageStatusEnable}
-                  customMessageStatus={customMessageStatus}
-                  unReadSentMessage={unReadSentMessage}
-                  unReadSeenMessage={unReadSeenMessage}
-                />
-                {enableTyping && <TypingIndicator typingUsers={typingUsers} />}
-              </>
-            )}
-          </div>
 
-          <div className="panel-input">
-            <div
-              className="input-box"
-              style={inputToolbarProps?.containerStyle}
-            >
-              {/* Camera button from inputToolbarProps */}
-              {showCamera && (
-                <ButtonMaterialIcon
-                  className="attach-btn"
-                  title="Camera"
-                  icon={inputToolbarProps?.cameraIcon || "photo_camera"}
-                  onClick={inputToolbarProps?.onPressCamera}
-                />
-              )}
-              {/* Gallery button from inputToolbarProps */}
-              {showGallery && (
-                <ButtonMaterialIcon
-                  className="attach-btn"
-                  title="Gallery"
-                  icon={inputToolbarProps?.galleryIcon || "photo_library"}
-                  onClick={inputToolbarProps?.onPressGallery}
-                />
-              )}
-              {/* Default file upload button */}
-              {showFileUploadBtn && (
-                <ButtonMaterialIcon
-                  className="attach-btn"
-                  title="Attach file"
-                  icon="attach_file"
-                  onClick={() => setShowUploader(true)}
-                />
-              )}
-              <div className="input-flex">
-                <MessageInput
-                  onSendMessage={handleSendTextMessage}
-                  onTyping={handleTyping}
-                  placeholder="Type your message..."
-                  className="message-input-reset"
-                />
+              <div className="panel-input">
+                <div
+                  className="input-box"
+                  style={inputToolbarProps?.containerStyle}
+                >
+                  {/* Camera button from inputToolbarProps */}
+                  {showCamera && (
+                    <ButtonMaterialIcon
+                      className="attach-btn"
+                      title="Camera"
+                      icon={inputToolbarProps?.cameraIcon || "photo_camera"}
+                      onClick={inputToolbarProps?.onPressCamera}
+                    />
+                  )}
+                  {/* Gallery button from inputToolbarProps */}
+                  {showGallery && (
+                    <ButtonMaterialIcon
+                      className="attach-btn"
+                      title="Gallery"
+                      icon={inputToolbarProps?.galleryIcon || "photo_library"}
+                      onClick={inputToolbarProps?.onPressGallery}
+                    />
+                  )}
+                  {/* Default file upload button */}
+                  {showFileUploadBtn && (
+                    <ButtonMaterialIcon
+                      className="attach-btn"
+                      title="Attach file"
+                      icon="attach_file"
+                      onClick={() => setShowUploader(true)}
+                    />
+                  )}
+                  <div className="input-flex">
+                    <MessageInput
+                      onSendMessage={handleSendTextMessage}
+                      onTyping={handleTyping}
+                      placeholder="Type your message..."
+                      className="message-input-reset"
+                    />
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            </>
+          )}
         </section>
       </div>
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -82,8 +82,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   }, []);
 
   return (
-    <div className={`w-full flex items-stretch space-x-2 bg-white ${className}`}>
-      <div className="flex-1 relative" style={{height: '40px'}}>
+    <div className={`w-full flex items-end gap-2 ${className}`}>
+      <div className="flex-1 flex items-center bg-gray-100 rounded-3xl px-4 py-2 min-h-[40px]">
         <TextareaAutosize
           ref={textareaRef}
           value={message}
@@ -95,24 +95,27 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           maxRows={5}
           minRows={1}
           className={`
-            w-full px-2 py-2 border-0 rounded-md resize-none bg-transparent text-gray-900 placeholder-gray-400
-            focus:outline-none focus:ring-0 focus:border-transparent
-            disabled:bg-transparent disabled:cursor-not-allowed
+            flex-1 bg-transparent resize-none text-gray-900 placeholder-gray-400
+            focus:outline-none focus:ring-0
+            disabled:cursor-not-allowed
           `}
+          style={{ border: 'none', outline: 'none', boxShadow: 'none' }}
         />
-
       </div>
 
       <ButtonMaterialIcon
         onClick={handleSend}
         disabled={disabled || !message.trim()}
-        className={`
-          self-stretch rounded-lg font-medium transition-colors flex items-center justify-center
-          ${disabled || !message.trim() ? '' : ''}
-        `}
+        className="flex items-center justify-center flex-shrink-0"
         style={{
-          background: disabled || !message.trim() ? '#e5e7eb' : '#1e88e5',
+          background: disabled || !message.trim() ? '#e5e7eb' : '#3b82f6',
           color: disabled || !message.trim() ? '#9ca3af' : '#fff',
+          borderRadius: '50%',
+          width: '40px',
+          height: '40px',
+          border: 'none',
+          cursor: disabled || !message.trim() ? 'not-allowed' : 'pointer',
+          transition: 'background 0.15s ease',
         }}
         title="Send message (Enter)"
         icon="send"

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { format, isToday, isYesterday, isSameDay } from "date-fns";
 import { Message, MessageListProps, IUser } from "../types";
 import { UserAvatar } from "./UserAvatar";
@@ -59,31 +58,13 @@ const MessageItem = React.memo(function MessageItem({
 }: MessageItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(message.text);
-  const [showActions, setShowActions] = useState(false);
 
-  const handleEdit = () => {
-    if (onUpdate && editText.trim() !== message.text) {
-      onUpdate({ ...message, text: editText.trim() });
-    }
-    setIsEditing(false);
-  };
+  const formattedTime = useMemo(
+    () => format(message.createdAt, "h:mm a"),
+    [message.createdAt]
+  );
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleEdit();
-    } else if (e.key === "Escape") {
-      setEditText(message.text);
-      setIsEditing(false);
-    }
-  };
-
-  const formatTime = (date: number) => {
-    return format(date, "h:mm a");
-  };
-
-  // Border radius logic: group consecutive messages
-  const getBubbleRadius = () => {
+  const bubbleRadius = useMemo(() => {
     const base = "18px";
     const small = "4px";
     if (isOwn) {
@@ -93,179 +74,183 @@ const MessageItem = React.memo(function MessageItem({
         borderTopRightRadius: isFirstInGroup ? base : small,
         borderBottomRightRadius: isLastInGroup ? base : small,
       };
-    } else {
-      return {
-        borderTopRightRadius: base,
-        borderBottomRightRadius: base,
-        borderTopLeftRadius: isFirstInGroup ? base : small,
-        borderBottomLeftRadius: isLastInGroup ? base : small,
-      };
     }
-  };
+    return {
+      borderTopRightRadius: base,
+      borderBottomRightRadius: base,
+      borderTopLeftRadius: isFirstInGroup ? base : small,
+      borderBottomLeftRadius: isLastInGroup ? base : small,
+    };
+  }, [isOwn, isFirstInGroup, isLastInGroup]);
+
+  const handleEdit = useCallback(() => {
+    if (onUpdate && editText.trim() !== message.text) {
+      onUpdate({ ...message, text: editText.trim() });
+    }
+    setIsEditing(false);
+  }, [onUpdate, editText, message]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleEdit();
+    } else if (e.key === "Escape") {
+      setEditText(message.text);
+      setIsEditing(false);
+    }
+  }, [handleEdit, message.text]);
 
   return (
     <>
       {showDateSeparator && <DateSeparator date={message.createdAt} />}
 
+      {/* `group` enables CSS-only hover for timestamp + action buttons — no React state */}
       <div
-        className={`flex items-end px-3 ${
-          isLastInGroup ? "mb-2" : "mb-0.5"
+        className={`group flex items-end ${
+          isLastInGroup ? "mb-4" : "mb-0.5"
         } ${isOwn ? "flex-row-reverse" : "flex-row"}`}
-        onMouseEnter={() => setShowActions(true)}
-        onMouseLeave={() => setShowActions(false)}
-        >
-          {/* Avatar for other users — uses partner info if available */}
-          {!isOwn && (
-            <div className="w-8 h-8 mr-1.5 flex-shrink-0 self-end">
-              {showAvatar && (
-                <UserAvatar
-                  user={partnerUser || {
+      >
+        {/* Avatar slot for received messages */}
+        {!isOwn && (
+          <div className="w-8 h-8 mr-1.5 flex-shrink-0 self-end">
+            {showAvatar && (
+              <UserAvatar
+                user={
+                  partnerUser || {
                     id: otherUserId || message.userId,
                     name: otherUserId || message.userId,
-                  }}
-                  size="small"
-                />
-              )}
-            </div>
+                  }
+                }
+                size="small"
+              />
+            )}
+          </div>
+        )}
+
+        <div
+          className={`max-w-xs lg:max-w-sm relative flex flex-col ${
+            isOwn ? "items-end" : "items-start"
+          }`}
+        >
+          {/* Sender name for received group messages */}
+          {!isOwn && isFirstInGroup && partnerUser?.name && (
+            <span className="text-xs text-gray-500 mb-1 ml-1 hm-msg-sender-name">
+              {partnerUser.name}
+            </span>
           )}
 
+          {/* Bubble */}
           <div
-            className={`max-w-xs lg:max-w-sm relative ${
-              isOwn ? "items-end" : "items-start"
-            } flex flex-col`}
+            className={`px-3 py-2 relative ${
+              isOwn ? "bg-blue-500 text-white" : "bg-gray-100 text-gray-900"
+            }`}
+            style={bubbleRadius}
           >
-            {/* Sender name for received messages */}
-            {!isOwn && isFirstInGroup && partnerUser?.name && (
-              <span className="text-xs text-gray-500 mb-1 ml-1 hm-msg-sender-name">
-                {partnerUser.name}
-              </span>
-            )}
-            {/* Message bubble */}
-            <div
-              className={`px-3 py-2 relative ${
-                isOwn
-                  ? "bg-blue-500 text-white"
-                  : "bg-white text-gray-900 shadow-sm"
-              }`}
-              style={getBubbleRadius()}
-            >
-              {isEditing ? (
-                <textarea
-                  value={editText}
-                  onChange={(e) => setEditText(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onBlur={handleEdit}
-                  className="w-full bg-transparent resize-none outline-none min-w-[160px]"
-                  autoFocus
-                />
-              ) : (
-                <>
-                  {message.type === "image" && message.metadata?.imageUrl ? (
-                    <div className="space-y-1">
-                      <img
-                        src={message.metadata.imageUrl}
-                        alt="Shared image"
-                        className="max-w-full h-auto rounded-xl"
-                        loading="lazy"
-                      />
-                      {message.text && (
-                        <p className="text-sm">{message.text}</p>
-                      )}
-                    </div>
-                  ) : (
-                    <p className="text-sm whitespace-pre-wrap break-words leading-snug">
-                      {message.text}
-                    </p>
-                  )}
-
-                  {message.updatedAt && (
-                    <span
-                      className={`text-xs ml-1 ${
-                        isOwn ? "text-blue-200" : "text-gray-400"
-                      }`}
-                    >
-                      (edited)
-                    </span>
-                  )}
-                </>
-              )}
-
-              {/* Timestamp inside bubble */}
-              <div
-                className={`text-right mt-0.5 text-xs ${
-                  isOwn ? "text-blue-200" : "text-gray-400"
-                }`}
-              >
-                {formatTime(message.createdAt)}
-              </div>
-            </div>
-
-            {/* Message status indicator (matching rn-firebase-chat) */}
-            {messageStatusEnable && isLastOwnMessage && (
-              <div className="mt-1 mr-1 self-end">
-                {customMessageStatus ? (
-                  customMessageStatus(!isSeen)
+            {isEditing ? (
+              <textarea
+                value={editText}
+                onChange={(e) => setEditText(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleEdit}
+                className="w-full bg-transparent resize-none outline-none min-w-[160px]"
+                autoFocus
+              />
+            ) : (
+              <>
+                {message.type === "image" && message.metadata?.imageUrl ? (
+                  <div className="space-y-1">
+                    <img
+                      src={message.metadata.imageUrl}
+                      alt="Shared image"
+                      className="max-w-full h-auto rounded-xl"
+                      loading="lazy"
+                    />
+                    {message.text && <p className="text-sm">{message.text}</p>}
+                  </div>
                 ) : (
-                  <span className="bg-gray-500 text-white text-xs font-medium px-2 py-0.5 rounded-full">
-                    {isSeen ? unReadSeenMessage : unReadSentMessage}
+                  <p className="text-sm whitespace-pre-wrap break-words leading-snug">
+                    {message.text}
+                  </p>
+                )}
+                {message.updatedAt && (
+                  <span
+                    className={`text-xs ml-1 ${
+                      isOwn ? "text-blue-200" : "text-gray-400"
+                    }`}
+                  >
+                    (edited)
                   </span>
                 )}
-              </div>
+              </>
             )}
           </div>
 
-          {/* Action buttons (edit/delete) */}
-          {showActions && isOwn && !isEditing && (
-            <motion.div
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              className="flex space-x-1 mx-2 self-center"
+          {/* Timestamp — always visible on last of group, hover pill on mid-group */}
+          {isLastInGroup ? (
+            <span
+              className={`text-xs text-gray-500 mt-0.5 px-2 py-0.5 ${
+                isOwn ? "self-end" : "self-start"
+              }`}
             >
-              <button
-                onClick={() => setIsEditing(true)}
-                className="p-1 text-gray-400 hover:text-gray-600 rounded"
-                title="Edit message"
+              {formattedTime}
+            </span>
+          ) : (
+            <span
+              className={`relative h-0 overflow-visible ${
+                isOwn ? "self-end" : "self-start"
+              }`}
+            >
+              <span
+                className={`absolute bottom-0 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded-full px-2 py-0.5 whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none shadow-sm ${
+                  isOwn ? "right-0" : "left-0"
+                }`}
               >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                  />
-                </svg>
-              </button>
-              <button
-                onClick={() => onDelete?.(message.id)}
-                className="p-1 text-gray-400 hover:text-red-600 rounded"
-                title="Delete message"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-              </button>
-            </motion.div>
+                {formattedTime}
+              </span>
+            </span>
+          )}
+
+          {/* Message status (Sent / Seen) */}
+          {messageStatusEnable && isLastOwnMessage && (
+            <div className="mt-1 mr-1 self-end">
+              {customMessageStatus ? (
+                customMessageStatus(!isSeen)
+              ) : (
+                <span className="bg-gray-500 text-white text-xs font-medium px-2 py-0.5 rounded-full">
+                  {isSeen ? unReadSeenMessage : unReadSentMessage}
+                </span>
+              )}
+            </div>
           )}
         </div>
-      </>
-    );
-  }
-);
+
+        {/* Action buttons — CSS-only visibility, zero React state updates on hover */}
+        {isOwn && !isEditing && (
+          <div className="flex space-x-1 mx-2 self-center opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+            <button
+              onClick={() => setIsEditing(true)}
+              className="p-1 text-gray-400 hover:text-gray-600 rounded"
+              title="Edit message"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            <button
+              onClick={() => onDelete?.(message.id)}
+              className="p-1 text-gray-400 hover:text-red-600 rounded"
+              title="Delete message"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+});
 
 export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }> = ({
   messages,
@@ -278,10 +263,18 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
   customMessageStatus,
   unReadSentMessage,
   unReadSeenMessage,
+  maxPageSize,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
+  const [pageCount, setPageCount] = useState(1);
+  const prevScrollHeightRef = useRef<number | null>(null);
+
+  // Reset pagination when conversation changes (messages go empty)
+  useEffect(() => {
+    if (messages.length === 0) setPageCount(1);
+  }, [messages.length]);
 
   useEffect(() => {
     if (autoScroll && messagesEndRef.current) {
@@ -289,33 +282,62 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
     }
   }, [messages, autoScroll]);
 
-  const handleScroll = () => {
-    if (containerRef.current) {
-      const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-      const isAtBottom = scrollHeight - scrollTop - clientHeight < 100;
-      setAutoScroll(isAtBottom);
+  // Restore scroll position after prepending older messages
+  useLayoutEffect(() => {
+    if (prevScrollHeightRef.current !== null && containerRef.current) {
+      containerRef.current.scrollTop +=
+        containerRef.current.scrollHeight - prevScrollHeightRef.current;
+      prevScrollHeightRef.current = null;
     }
-  };
+  });
 
-  // Find last own message index
-  const lastOwnMessageIndex = messages.reduce((last, msg, index) => {
-    return msg.userId === currentUser.id ? index : last;
-  }, -1);
+  const displayedMessages = useMemo(() => {
+    if (!maxPageSize) return messages;
+    return messages.slice(Math.max(0, messages.length - pageCount * maxPageSize));
+  }, [messages, pageCount, maxPageSize]);
 
-  // Check if the last own message has been seen by anyone else
-  const isLastOwnMessageSeen = (() => {
+  const hasMore = !!maxPageSize && messages.length > pageCount * maxPageSize;
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || !containerRef.current) return;
+    prevScrollHeightRef.current = containerRef.current.scrollHeight;
+    setPageCount((p) => p + 1);
+  }, [hasMore]);
+
+  const handleScroll = useCallback(() => {
+    if (!containerRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    setAutoScroll(scrollHeight - scrollTop - clientHeight < 100);
+    if (scrollTop < 40) loadMore();
+  }, [loadMore]);
+
+  // O(1) partner lookup — rebuilt only when partnerUsers reference changes
+  const partnerUserMap = useMemo(() => {
+    const map = new Map<string, IUser>();
+    partnerUsers?.forEach((u) => map.set(u.id, u));
+    return map;
+  }, [partnerUsers]);
+
+  const lastOwnMessageIndex = useMemo(
+    () =>
+      displayedMessages.reduce(
+        (last, msg, index) => (msg.userId === currentUser.id ? index : last),
+        -1
+      ),
+    [displayedMessages, currentUser.id]
+  );
+
+  const isLastOwnMessageSeen = useMemo(() => {
     if (lastOwnMessageIndex < 0) return false;
-    const lastMsg = messages[lastOwnMessageIndex];
+    const lastMsg = displayedMessages[lastOwnMessageIndex];
     return Object.entries(lastMsg.readBy || {}).some(
       ([uid, read]) => uid !== currentUser.id && read
     );
-  })();
+  }, [displayedMessages, lastOwnMessageIndex, currentUser.id]);
 
   if (messages.length === 0) {
     return (
-      <div
-        className={`flex-1 flex items-center justify-center p-8 bg-gray-100 ${className}`}
-      >
+      <div className={`flex-1 flex items-center justify-center p-8 bg-white ${className}`}>
         <div className="text-center text-gray-500">
           <div className="text-4xl mb-4">💬</div>
           <p className="text-lg font-medium">No messages yet</p>
@@ -329,63 +351,58 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className={`flex-1 overflow-y-auto bg-gray-100 py-2 ${className}`}
+      className={`flex-1 overflow-y-auto bg-white px-4 py-4 ${className}`}
     >
-      <AnimatePresence>
-        {messages.map((message, index) => {
-          const isOwn = message.userId === currentUser.id;
+      {hasMore && (
+        <div className="flex justify-center py-2">
+          <button
+            onClick={loadMore}
+            className="text-xs text-gray-500 bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded-full transition-colors"
+          >
+            Load earlier messages
+          </button>
+        </div>
+      )}
+      {displayedMessages.map((message, index) => {
+        const isOwn = message.userId === currentUser.id;
+        const prevMessage = index > 0 ? displayedMessages[index - 1] : null;
+        const nextMessage = index < displayedMessages.length - 1 ? displayedMessages[index + 1] : null;
 
-          const prevMessage = index > 0 ? messages[index - 1] : null;
-          const nextMessage =
-            index < messages.length - 1 ? messages[index + 1] : null;
+        const isFirstInGroup = !prevMessage || prevMessage.userId !== message.userId;
+        const isLastInGroup = !nextMessage || nextMessage.userId !== message.userId;
+        const showDateSeparator =
+          !prevMessage ||
+          !isSameDay(new Date(message.createdAt), new Date(prevMessage.createdAt));
+        const showAvatar = !isOwn && isLastInGroup;
+        const isLastOwnMessage = isOwn && index === lastOwnMessageIndex;
 
-          const isFirstInGroup =
-            !prevMessage || prevMessage.userId !== message.userId;
-          const isLastInGroup =
-            !nextMessage || nextMessage.userId !== message.userId;
+        // Fallback: first partner in list if per-user lookup misses
+        const partnerUser =
+          partnerUserMap.get(message.userId) ?? partnerUsers?.[0];
 
-          const showDateSeparator =
-            !prevMessage ||
-            !isSameDay(
-              new Date(message.createdAt),
-              new Date(prevMessage.createdAt)
-            );
-
-          // For other-user avatars, show only on last message of their group
-          const showAvatar = !isOwn && isLastInGroup;
-
-          const isLastOwnMessage =
-            isOwn && index === lastOwnMessageIndex;
-
-          return (
-            <motion.div
-              key={message.id}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-            >
-              <MessageItem
-                message={message}
-                isOwn={isOwn}
-                showAvatar={showAvatar}
-                isFirstInGroup={isFirstInGroup}
-                isLastInGroup={isLastInGroup}
-                showDateSeparator={showDateSeparator}
-                isLastOwnMessage={isLastOwnMessage}
-                isSeen={isLastOwnMessageSeen}
-                otherUserId={message.userId}
-                partnerUser={partnerUsers?.find((p) => p.id === message.userId) || partnerUsers?.[0]}
-                onUpdate={onMessageUpdate}
-                onDelete={onMessageDelete}
-                messageStatusEnable={messageStatusEnable}
-                customMessageStatus={customMessageStatus}
-                unReadSentMessage={unReadSentMessage}
-                unReadSeenMessage={unReadSeenMessage}
-              />
-            </motion.div>
-          );
-        })}
-      </AnimatePresence>
+        return (
+          <div key={message.id} className="animate-fade-in">
+            <MessageItem
+              message={message}
+              isOwn={isOwn}
+              showAvatar={showAvatar}
+              isFirstInGroup={isFirstInGroup}
+              isLastInGroup={isLastInGroup}
+              showDateSeparator={showDateSeparator}
+              isLastOwnMessage={isLastOwnMessage}
+              isSeen={isLastOwnMessageSeen}
+              otherUserId={message.userId}
+              partnerUser={partnerUser}
+              onUpdate={onMessageUpdate}
+              onDelete={onMessageDelete}
+              messageStatusEnable={messageStatusEnable}
+              customMessageStatus={customMessageStatus}
+              unReadSentMessage={unReadSentMessage}
+              unReadSeenMessage={unReadSeenMessage}
+            />
+          </div>
+        );
+      })}
       <div ref={messagesEndRef} />
     </div>
   );

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -12,14 +12,13 @@ interface MessageItemProps {
   showDateSeparator: boolean;
   isLastOwnMessage: boolean;
   isSeen: boolean;
-  otherUserId?: string;
   partnerUser?: IUser;
   onUpdate?: (message: Message) => void;
   onDelete?: (messageId: string) => void;
   messageStatusEnable?: boolean;
   customMessageStatus?: (hasUnread: boolean) => React.ReactNode;
-  unReadSentMessage?: string;
-  unReadSeenMessage?: string;
+  sentMessageLabel?: string;
+  seenMessageLabel?: string;
 }
 
 const DateSeparator: React.FC<{ date: number }> = ({ date }) => {
@@ -38,6 +37,47 @@ const DateSeparator: React.FC<{ date: number }> = ({ date }) => {
   );
 };
 
+const MessageStatus: React.FC<{ isSeen: boolean; sentLabel?: string; seenLabel?: string }> = ({
+  isSeen,
+  sentLabel = "Sent",
+  seenLabel = "Seen",
+}) => (
+  <span
+    className="flex items-center gap-0.5"
+    title={isSeen ? seenLabel : sentLabel}
+    aria-label={isSeen ? seenLabel : sentLabel}
+  >
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={isSeen ? "#3b82f6" : "#9ca3af"}
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+
+    {isSeen && (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#3b82f6"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ marginLeft: "-8px" }}
+      >
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    )}
+  </span>
+);
+
 const MessageItem = React.memo(function MessageItem({
   message,
   isOwn,
@@ -47,17 +87,21 @@ const MessageItem = React.memo(function MessageItem({
   showDateSeparator,
   isLastOwnMessage,
   isSeen,
-  otherUserId,
   partnerUser,
   onUpdate,
   onDelete,
   messageStatusEnable = true,
   customMessageStatus,
-  unReadSentMessage = "Sent",
-  unReadSeenMessage = "Seen",
+  sentMessageLabel = "Sent",
+  seenMessageLabel = "Seen",
 }: MessageItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(message.text);
+
+  // Sync edit buffer when the message is updated externally
+  useEffect(() => {
+    if (!isEditing) setEditText(message.text);
+  }, [message.text, isEditing]);
 
   const formattedTime = useMemo(
     () => format(message.createdAt, "h:mm a"),
@@ -101,7 +145,7 @@ const MessageItem = React.memo(function MessageItem({
   }, [handleEdit, message.text]);
 
   return (
-    <>
+    <div className="animate-fade-in">
       {showDateSeparator && <DateSeparator date={message.createdAt} />}
 
       {/* `group` enables CSS-only hover for timestamp + action buttons — no React state */}
@@ -115,12 +159,7 @@ const MessageItem = React.memo(function MessageItem({
           <div className="w-8 h-8 mr-1.5 flex-shrink-0 self-end">
             {showAvatar && (
               <UserAvatar
-                user={
-                  partnerUser || {
-                    id: otherUserId || message.userId,
-                    name: otherUserId || message.userId,
-                  }
-                }
+                user={partnerUser || { id: message.userId, name: message.userId }}
                 size="small"
               />
             )}
@@ -146,6 +185,17 @@ const MessageItem = React.memo(function MessageItem({
             }`}
             style={bubbleRadius}
           >
+            {/* Mid-group timestamp — above the bubble, no layout impact */}
+            {!isLastInGroup && (
+              <span
+                className={`absolute -top-6 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded-full px-2 py-0.5 whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none shadow-sm ${
+                  isOwn ? "right-0" : "left-0"
+                }`}
+              >
+                {formattedTime}
+              </span>
+            )}
+
             {isEditing ? (
               <textarea
                 value={editText}
@@ -173,11 +223,7 @@ const MessageItem = React.memo(function MessageItem({
                   </p>
                 )}
                 {message.updatedAt && (
-                  <span
-                    className={`text-xs ml-1 ${
-                      isOwn ? "text-blue-200" : "text-gray-400"
-                    }`}
-                  >
+                  <span className={`text-xs ml-1 ${isOwn ? "text-blue-200" : "text-gray-400"}`}>
                     (edited)
                   </span>
                 )}
@@ -185,8 +231,8 @@ const MessageItem = React.memo(function MessageItem({
             )}
           </div>
 
-          {/* Timestamp — always visible on last of group, hover pill on mid-group */}
-          {isLastInGroup ? (
+          {/* Timestamp — always visible on last of group */}
+          {isLastInGroup && (
             <span
               className={`text-xs text-gray-500 mt-0.5 px-2 py-0.5 ${
                 isOwn ? "self-end" : "self-start"
@@ -194,31 +240,15 @@ const MessageItem = React.memo(function MessageItem({
             >
               {formattedTime}
             </span>
-          ) : (
-            <span
-              className={`relative h-0 overflow-visible ${
-                isOwn ? "self-end" : "self-start"
-              }`}
-            >
-              <span
-                className={`absolute bottom-0 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded-full px-2 py-0.5 whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none shadow-sm ${
-                  isOwn ? "right-0" : "left-0"
-                }`}
-              >
-                {formattedTime}
-              </span>
-            </span>
           )}
 
-          {/* Message status (Sent / Seen) */}
+          {/* Message status */}
           {messageStatusEnable && isLastOwnMessage && (
-            <div className="mt-1 mr-1 self-end">
+            <div className="mt-0.5 mr-1 self-end">
               {customMessageStatus ? (
                 customMessageStatus(!isSeen)
               ) : (
-                <span className="bg-gray-500 text-white text-xs font-medium px-2 py-0.5 rounded-full">
-                  {isSeen ? unReadSeenMessage : unReadSentMessage}
-                </span>
+                <MessageStatus isSeen={isSeen} sentLabel={sentMessageLabel} seenLabel={seenMessageLabel} />
               )}
             </div>
           )}
@@ -248,7 +278,7 @@ const MessageItem = React.memo(function MessageItem({
           </div>
         )}
       </div>
-    </>
+    </div>
   );
 });
 
@@ -318,22 +348,15 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
     return map;
   }, [partnerUsers]);
 
-  const lastOwnMessageIndex = useMemo(
-    () =>
-      displayedMessages.reduce(
-        (last, msg, index) => (msg.userId === currentUser.id ? index : last),
-        -1
-      ),
-    [displayedMessages, currentUser.id]
-  );
+  const lastMessage = displayedMessages[displayedMessages.length - 1];
+  const lastMessageIndex = displayedMessages.length - 1;
 
   const isLastOwnMessageSeen = useMemo(() => {
-    if (lastOwnMessageIndex < 0) return false;
-    const lastMsg = displayedMessages[lastOwnMessageIndex];
-    return Object.entries(lastMsg.readBy || {}).some(
+    if (!lastMessage || lastMessage.userId !== currentUser.id) return false;
+    return Object.entries(lastMessage.readBy || {}).some(
       ([uid, read]) => uid !== currentUser.id && read
     );
-  }, [displayedMessages, lastOwnMessageIndex, currentUser.id]);
+  }, [lastMessage, currentUser.id]);
 
   if (messages.length === 0) {
     return (
@@ -373,34 +396,26 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
         const showDateSeparator =
           !prevMessage ||
           !isSameDay(new Date(message.createdAt), new Date(prevMessage.createdAt));
-        const showAvatar = !isOwn && isLastInGroup;
-        const isLastOwnMessage = isOwn && index === lastOwnMessageIndex;
-
-        // Fallback: first partner in list if per-user lookup misses
-        const partnerUser =
-          partnerUserMap.get(message.userId) ?? partnerUsers?.[0];
 
         return (
-          <div key={message.id} className="animate-fade-in">
-            <MessageItem
-              message={message}
-              isOwn={isOwn}
-              showAvatar={showAvatar}
-              isFirstInGroup={isFirstInGroup}
-              isLastInGroup={isLastInGroup}
-              showDateSeparator={showDateSeparator}
-              isLastOwnMessage={isLastOwnMessage}
-              isSeen={isLastOwnMessageSeen}
-              otherUserId={message.userId}
-              partnerUser={partnerUser}
-              onUpdate={onMessageUpdate}
-              onDelete={onMessageDelete}
-              messageStatusEnable={messageStatusEnable}
-              customMessageStatus={customMessageStatus}
-              unReadSentMessage={unReadSentMessage}
-              unReadSeenMessage={unReadSeenMessage}
-            />
-          </div>
+          <MessageItem
+            key={message.id}
+            message={message}
+            isOwn={isOwn}
+            showAvatar={!isOwn && isLastInGroup}
+            isFirstInGroup={isFirstInGroup}
+            isLastInGroup={isLastInGroup}
+            showDateSeparator={showDateSeparator}
+            isLastOwnMessage={isOwn && index === lastMessageIndex}
+            isSeen={isLastOwnMessageSeen}
+            partnerUser={partnerUserMap.get(message.userId) ?? partnerUsers?.[0]}
+            onUpdate={onMessageUpdate}
+            onDelete={onMessageDelete}
+            messageStatusEnable={messageStatusEnable}
+            customMessageStatus={customMessageStatus}
+            sentMessageLabel={unReadSentMessage}
+            seenMessageLabel={unReadSeenMessage}
+          />
         );
       })}
       <div ref={messagesEndRef} />

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './services/user';
 
 // React components
 export * from './components/ChatScreen';
+export * from './components/ChatHeader';
 export * from './components/MessageList';
 export * from './components/MessageInput';
 export * from './components/UserAvatar';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -328,6 +328,8 @@ export interface MessageListProps {
   customMessageStatus?: (hasUnread: boolean) => React.ReactNode;
   unReadSentMessage?: string;
   unReadSeenMessage?: string;
+  /** Max messages to display per page; scroll to top loads the previous page */
+  maxPageSize?: number;
 }
 
 export interface MessageInputProps {


### PR DESCRIPTION
…ssage pagination

- Merge ChatPanelHeader into ChatHeader with onBack support; back button shows ConversationList on mobile
- Move current user to sidebar avatar menu with logout popup
- iOS-style message bubbles with group-aware corner radii
- Timestamp: always visible on last-in-group, hover pill for mid-group (zero layout impact)
- CSS-only hover for message actions and timestamps (no React state on hover)
- Pill-shaped input with round send button
- Responsive layout: single-panel on mobile, side-by-side on desktop
- Add maxPageSize pagination to MessageList with scroll-position preservation
- Fix onBack: use selectedConversationId alone for has-conversation class so back clears the panel
- Demo: add CSS import and Vite aliases to load library source directly