### PR TITLE
fix: Firestore perf, message order, unread logic, typing, and Enter to send

### DIFF
--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -176,8 +176,8 @@ export const ChatList: React.FC<ChatListProps> = ({
                 </span>
               </div>
             </div>
-            {(c.unRead?.[currentUser?.id ?? ""] || 0) > 0 && (
-              <span className="unread-badge">{c.unRead?.[currentUser?.id ?? ""] || 0}</span>
+            {selectedConversationId !== c.id && (c.unRead?.[String(currentUser?.id ?? "")] || 0) > 0 && (
+              <span className="unread-badge">{c.unRead?.[String(currentUser?.id ?? "")] || 0}</span>
             )}
           </button>
         ))}

--- a/src/components/ChatScreen.tsx
+++ b/src/components/ChatScreen.tsx
@@ -210,6 +210,22 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
     return map;
   }, [selectedPartners]);
 
+  const convId = selectedConversationId || effectiveConversationId;
+
+  /**
+   * Derived from the already-live conversations list — no extra Firestore listener needed.
+   * Same logic as rn-firebase-chat useChatScreen: true when any other member has a
+   * different unRead count than me (they haven't read my last message yet → "Sent").
+   */
+  const userUnreadMessage = useMemo(() => {
+    if (!convId || !currentUser?.id) return false;
+    const conv = conversations.find((c) => c.id === convId);
+    if (!conv?.unRead) return false;
+    const myId = String(currentUser.id);
+    const myUnread = conv.unRead[myId] ?? 0;
+    return Object.entries(conv.unRead).some(([uid, v]) => uid !== myId && v !== myUnread);
+  }, [conversations, convId, currentUser?.id]);
+
   const chatName = useMemo(
     () =>
       isGroup
@@ -220,16 +236,23 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
 
   const { messages, loading, error, sendMessage, updateMessage, markAsRead } = useChat({
     user: currentUser,
-    conversationId: selectedConversationId || effectiveConversationId,
+    conversationId: convId,
     memberIds,
     name: chatName,
   });
 
-  // Typing hook with configurable timeout
+  // Derive typing data from the already-live conversations state (no extra listener)
+  const selectedConversationTyping = useMemo(() => {
+    if (!convId) return undefined;
+    return conversations.find((c) => c.id === convId)?.typing;
+  }, [conversations, convId]);
+
+  // Typing hook — write side only; read side comes from subscribeToUserConversations
   const { typingUsers, setTyping } = useTyping(
-    selectedConversationId || effectiveConversationId || "",
+    convId || "",
     `${currentUser.id}`,
-    typingTimeoutSeconds
+    typingTimeoutSeconds,
+    selectedConversationTyping
   );
 
   // Lifecycle callbacks
@@ -306,25 +329,32 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser?.id]);
 
-  // Reset unread count when a conversation is selected
+  // Mark as read when the conversation is selected or when new messages arrive while viewing.
+  // This ensures unread is never incremented for a user who is actively on the screen.
   useEffect(() => {
-    if (selectedConversationId) {
-      markAsRead();
-    }
-  }, [selectedConversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!convId || messages.length === 0) return;
+    markAsRead();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [convId, messages.length]);
 
-  // Resolve partner avatars when conversations load and partners are missing avatar info
-  // Fixed: removed selectedPartners from deps to prevent infinite loop
-  // (resolvePartners -> setSelectedPartners -> re-trigger this effect)
+  // Track which conversation ID we've already resolved partners for.
+  // Without this, the effect would fire on every conversation-list update
+  // (new message, unread change, etc.) and trigger N getUserById reads each time.
+  const resolvedConvIdRef = useRef<string | undefined>(undefined);
+
+  // Resolve partner avatars — only when the selected conversation actually changes,
+  // not on every conversations-list update (which would re-fire on every message).
   useEffect(() => {
-    const convId = selectedConversationId || effectiveConversationId;
     if (!convId || conversations.length === 0) return;
+    // Skip if we already resolved this exact conversation
+    if (resolvedConvIdRef.current === convId) return;
     const conv = conversations.find((c) => c.id === convId);
     if (conv) {
+      resolvedConvIdRef.current = convId;
       resolvePartners(conv);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [conversations, selectedConversationId, effectiveConversationId]);
+  }, [conversations, convId]);
 
   const handleSendMessage = useCallback(
     async (text: string) => {
@@ -437,6 +467,7 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
 
   const handleSelectConversation = useCallback(
     (conversation: ConversationProps) => {
+      resolvedConvIdRef.current = conversation.id; // mark resolved before resolvePartners sets state
       setSelectedConversationId(conversation.id);
       setSelectedName(conversation.name || "");
       resolvePartners(conversation);
@@ -539,6 +570,7 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
                       unReadSentMessage={unReadSentMessage}
                       unReadSeenMessage={unReadSeenMessage}
                       maxPageSize={maxPageSize}
+                      userUnreadMessage={userUnreadMessage}
                     />
                     {enableTyping && <TypingIndicator typingUsers={typingUsers} />}
                   </>

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -66,13 +66,6 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [onTyping, isTyping, maxInputLength]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  }, []);
-
   const handleSend = useCallback(() => {
     const trimmedMessage = message.trim();
     if (trimmedMessage && !disabled) {
@@ -95,6 +88,13 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       textareaRef.current?.focus();
     }
   }, [message, disabled, onSendMessage, isTyping, onTyping]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }, [handleSend]);
 
   const handlePaste = useCallback((_e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     // Paste is allowed — max length is enforced on change

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -303,32 +303,25 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
   unReadSentMessage,
   unReadSeenMessage,
   maxPageSize,
+  userUnreadMessage = false,
 }) => {
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [pageCount, setPageCount] = useState(1);
-  const prevScrollHeightRef = useRef<number | null>(null);
+  // Saved scrollHeight before prepending older messages — used to restore position
+  const prevScrollHeightRef = useRef(0);
 
   // Reset pagination when conversation changes (messages go empty)
   useEffect(() => {
     if (messages.length === 0) setPageCount(1);
   }, [messages.length]);
 
+  // Scroll to bottom when a new message arrives and the user is already at the bottom
   useEffect(() => {
-    if (autoScroll && messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    if (autoScroll && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
   }, [messages, autoScroll]);
-
-  // Restore scroll position after prepending older messages
-  useLayoutEffect(() => {
-    if (prevScrollHeightRef.current !== null && containerRef.current) {
-      containerRef.current.scrollTop +=
-        containerRef.current.scrollHeight - prevScrollHeightRef.current;
-      prevScrollHeightRef.current = null;
-    }
-  });
 
   const displayedMessages = useMemo(() => {
     if (!maxPageSize) return messages;
@@ -338,15 +331,29 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
   const hasMore = !!maxPageSize && messages.length > pageCount * maxPageSize;
 
   const loadMore = useCallback(() => {
-    if (!hasMore || !containerRef.current) return;
-    prevScrollHeightRef.current = containerRef.current.scrollHeight;
+    if (!hasMore) return;
+    // Save scroll height before older messages are prepended so we can restore position
+    if (containerRef.current) {
+      prevScrollHeightRef.current = containerRef.current.scrollHeight;
+    }
     setPageCount((p) => p + 1);
   }, [hasMore]);
+
+  // After older messages are prepended, restore scroll position so the view doesn't jump
+  useLayoutEffect(() => {
+    if (prevScrollHeightRef.current && containerRef.current) {
+      const added = containerRef.current.scrollHeight - prevScrollHeightRef.current;
+      containerRef.current.scrollTop += added;
+      prevScrollHeightRef.current = 0;
+    }
+  });
 
   const handleScroll = useCallback(() => {
     if (!containerRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    // Auto-scroll is active when the user is near the bottom (newest messages)
     setAutoScroll(scrollHeight - scrollTop - clientHeight < 100);
+    // Load older messages when the user scrolls near the top
     if (scrollTop < 40) loadMore();
   }, [loadMore]);
 
@@ -357,15 +364,10 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
     return map;
   }, [partnerUsers]);
 
-  const lastMessage = displayedMessages[displayedMessages.length - 1];
-  const lastMessageIndex = displayedMessages.length - 1;
+  // Render in natural order: oldest at top, newest at bottom
+  const renderedMessages = displayedMessages;
 
-  const isLastOwnMessageSeen = useMemo(() => {
-    if (!lastMessage || lastMessage.userId !== currentUser.id) return false;
-    return Object.entries(lastMessage.readBy || {}).some(
-      ([uid, read]) => uid !== currentUser.id && read
-    );
-  }, [lastMessage, currentUser.id]);
+  const isLastOwnMessageSeen = !userUnreadMessage;
 
   if (messages.length === 0) {
     return (
@@ -385,6 +387,7 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
       onScroll={handleScroll}
       className={`flex-1 overflow-y-auto bg-white px-4 py-4 ${className}`}
     >
+      {/* "Load earlier" sits at the top — that's where older messages live */}
       {hasMore && (
         <div className="flex justify-center py-2">
           <button
@@ -395,13 +398,20 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
           </button>
         </div>
       )}
-      {displayedMessages.map((message, index) => {
+      {renderedMessages.map((message, index) => {
         const isOwn = message.userId === currentUser.id;
-        const prevMessage = index > 0 ? displayedMessages[index - 1] : null;
-        const nextMessage = index < displayedMessages.length - 1 ? displayedMessages[index + 1] : null;
+        // Natural order: prevMessage is chronologically older (visually above),
+        // nextMessage is chronologically newer (visually below).
+        const prevMessage = index > 0 ? renderedMessages[index - 1] : null;
+        const nextMessage = index < renderedMessages.length - 1 ? renderedMessages[index + 1] : null;
 
+        // isFirstInGroup: no message from the same user immediately above this one
         const isFirstInGroup = !prevMessage || prevMessage.userId !== message.userId;
+        // isLastInGroup: no message from the same user immediately below this one
         const isLastInGroup = !nextMessage || nextMessage.userId !== message.userId;
+
+        // Show a date separator above the first message of each day.
+        // prevMessage is chronologically older (visually above); separator fires when the day changes.
         const showDateSeparator =
           !prevMessage ||
           !isSameDay(new Date(message.createdAt), new Date(prevMessage.createdAt));
@@ -415,7 +425,8 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
             isFirstInGroup={isFirstInGroup}
             isLastInGroup={isLastInGroup}
             showDateSeparator={showDateSeparator}
-            isLastOwnMessage={isOwn && index === lastMessageIndex}
+            // last index = newest own message (chronologically last sent)
+            isLastOwnMessage={isOwn && index === renderedMessages.length - 1}
             isSeen={isLastOwnMessageSeen}
             partnerUser={partnerUserMap.get(message.userId) ?? partnerUsers?.[0]}
             onDelete={onMessageDelete}
@@ -428,7 +439,6 @@ export const MessageList: React.FC<MessageListProps & { partnerUsers?: IUser[] }
           />
         );
       })}
-      <div ref={messagesEndRef} />
     </div>
   );
 };

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -55,7 +55,7 @@ export const useChat = ({ user, conversationId, memberIds, name }: UseChatProps)
     convertMessages(rawMessagesRef.current, effectiveKey).then(setMessages);
   }, [effectiveKey]);
 
-  // Stable subscription — never torn down unless conversationId changes
+  // Message subscription — never torn down unless conversationId changes
   useEffect(() => {
     if (!conversationId) {
       setLoading(false);
@@ -155,13 +155,10 @@ export const useChat = ({ user, conversationId, memberIds, name }: UseChatProps)
     }
   }, [conversationId, chatService]);
 
-  // Mark message as read
+  // Mark conversation as read — resets current user's unRead to 0 (matching rn-firebase-chat changeReadMessage)
   const markAsRead = useCallback(async () => {
     try {
-      if (!conversationId) {
-        console.log('No conversation selected');
-        return;
-      }
+      if (!conversationId) return;
       await chatService.updateUnread(conversationId, user.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to mark as read');
@@ -173,6 +170,7 @@ export const useChat = ({ user, conversationId, memberIds, name }: UseChatProps)
     messages,
     loading,
     error,
+    userUnreadMessage: false, // Computed in ChatScreen from conversations state — no extra listener
     sendMessage,
     updateMessage,
     deleteMessage,

--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -3,63 +3,60 @@ import { ChatService } from '../services/chat';
 import { TypingUser, UseTypingReturn } from '../types';
 import { DEFAULT_TYPING_TIMEOUT_SECONDS } from '../utils/constants';
 
+/**
+ * Manages the "I am typing" write side only.
+ * Typing state for other users is derived from the conversation document
+ * that subscribeToUserConversations already listens to — no extra snapshot needed.
+ *
+ * @param roomId - conversation ID
+ * @param userId - current user ID
+ * @param typingTimeoutSeconds - inactivity ms before typing stops
+ * @param externalTypingData - typing map from the live conversation document
+ */
 export const useTyping = (
   roomId: string,
   userId: string,
-  typingTimeoutSeconds: number = DEFAULT_TYPING_TIMEOUT_SECONDS
+  typingTimeoutSeconds: number = DEFAULT_TYPING_TIMEOUT_SECONDS,
+  externalTypingData?: Record<string, boolean>
 ): UseTypingReturn => {
   const chatService = ChatService.getInstance();
 
-  const [typingUsers, setTypingUsers] = useState<TypingUser[]>([]);
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isTypingRef = useRef(false);
 
+  // Derive typingUsers from the conversation document data passed in from ChatScreen
+  const [typingUsers, setTypingUsers] = useState<TypingUser[]>([]);
+
   useEffect(() => {
-    if (!roomId) return;
-
-    const unsubscribe = chatService.subscribeToTypingStatus(roomId, (typingUsers: Record<string, boolean>) => {
-      // Convert typing users object to array and filter out current user
-      const usersArray: TypingUser[] = Object.entries(typingUsers)
-        .filter(([uid, isTyping]) => uid !== userId && isTyping)
-        .map(([uid]) => ({
-          uid,
-          displayName: `User ${uid}`,
-          timestamp: Date.now(),
-        }));
-
-      setTypingUsers(usersArray);
-    });
-
-    return unsubscribe;
-  }, [roomId, userId, chatService]);
+    if (!externalTypingData) return;
+    const users: TypingUser[] = Object.entries(externalTypingData)
+      .filter(([uid, isTyping]) => uid !== userId && isTyping)
+      .map(([uid]) => ({ uid, displayName: `User ${uid}`, timestamp: Date.now() }));
+    setTypingUsers(users);
+  }, [externalTypingData, userId]);
 
   const setTyping = useCallback((isTyping: boolean): void => {
     if (!userId || !roomId) return;
 
-    // Clear existing timeout
     if (typingTimeoutRef.current) {
       clearTimeout(typingTimeoutRef.current);
       typingTimeoutRef.current = null;
     }
 
     if (isTyping) {
-      // Only send typing indicator if not already typing
       if (!isTypingRef.current) {
         chatService.updateTypingStatus(roomId, userId, true);
         isTypingRef.current = true;
       }
-
-      // Set timeout to stop typing indicator (configurable)
       typingTimeoutRef.current = setTimeout(() => {
         chatService.updateTypingStatus(roomId, userId, false);
         isTypingRef.current = false;
       }, typingTimeoutSeconds);
     } else {
-      // Immediately stop typing
       chatService.updateTypingStatus(roomId, userId, false);
       isTypingRef.current = false;
     }
-  }, [roomId, userId, typingTimeoutSeconds]);
+  }, [roomId, userId, typingTimeoutSeconds, chatService]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -68,17 +65,10 @@ export const useTyping = (
         clearTimeout(typingTimeoutRef.current);
       }
       if (isTypingRef.current && roomId && userId) {
-        try {
-          chatService.updateTypingStatus(roomId, userId, false);
-        } catch (error) {
-          console.error('Error cleanup typing:', error);
-        }
+        chatService.updateTypingStatus(roomId, userId, false);
       }
     };
   }, [roomId, userId, chatService]);
 
-  return {
-    typingUsers,
-    setTyping,
-  };
+  return { typingUsers, setTyping };
 };

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -15,7 +15,6 @@ import {
   getDoc,
   serverTimestamp,
   DocumentSnapshot,
-  Unsubscribe,
   increment,
 } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
@@ -52,6 +51,12 @@ export class ChatService {
 
   /** Custom storage provider */
   private storageProvider?: StorageProvider;
+
+  /**
+   * In-memory set of conversation IDs known to exist in Firestore.
+   * Avoids a getDoc existence check on every sendMessage after the first.
+   */
+  private knownConversations = new Set<string>();
 
   constructor() {
     this.db = getFirebaseFirestore();
@@ -146,15 +151,11 @@ export class ChatService {
       let docRefId: string;
 
       if (conversationId) {
-        await updateDoc(
+        // setDoc creates-or-overwrites in a single write — no updateDoc+catch needed
+        await setDoc(
           doc(this.db, this.CONVERSATIONS, conversationId),
           conversationData
-        ).catch(async () => {
-          await setDoc(
-            doc(this.db, this.CONVERSATIONS, conversationId),
-            conversationData
-          );
-        });
+        );
         docRefId = conversationId;
       } else {
         const docRef = await addDoc(
@@ -164,8 +165,11 @@ export class ChatService {
         docRefId = docRef.id;
       }
 
-      // Ensure user documents exist for all members
-      await Promise.all(memberIds.map((id) => this.userService.createUserIfNotExists(id)));
+      this.knownConversations.add(docRefId);
+
+      // Ensure user documents exist for all members (fire-and-forget, non-blocking)
+      Promise.all(memberIds.map((id) => this.userService.createUserIfNotExists(id)))
+        .catch((err) => console.error('Error ensuring user documents:', err));
 
       return docRefId;
     } catch (error) {
@@ -175,11 +179,17 @@ export class ChatService {
   }
 
   private async conversationExists(conversationId: string): Promise<boolean> {
+    // Fast path: if we've seen this conversation before, skip the network read
+    if (this.knownConversations.has(conversationId)) return true;
     try {
       const conversationDoc = await getDoc(
         doc(this.db, this.CONVERSATIONS, conversationId)
       );
-      return conversationDoc.exists();
+      if (conversationDoc.exists()) {
+        this.knownConversations.add(conversationId);
+        return true;
+      }
+      return false;
     } catch (error) {
       console.error('Error checking conversation existence:', error);
       return false;
@@ -234,37 +244,29 @@ export class ChatService {
         messageData
       );
 
+      // Build a single atomic conversation update (matching rn-firebase-chat):
+      // - latestMessage + timestamps
+      // - sender's unRead reset to 0 (they just read their own message)
+      // - all other members' unRead incremented by 1
+      const senderId = String(message.senderId);
+      const conversationUpdate: Record<string, unknown> = {
+        latestMessage: convertToLatestMessage(senderId, conversationOptions?.name || '', filteredText || ''),
+        latestMessageTime: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        [`unRead.${senderId}`]: 0,
+      };
+      memberIds.forEach((memberId) => {
+        if (memberId !== senderId) {
+          conversationUpdate[`unRead.${memberId}`] = increment(1);
+        }
+      });
+
       await updateDoc(
         doc(this.db, this.CONVERSATIONS, conversationId),
-        {
-          latestMessage: { ...messageData, id: messageRef.id },
-          latestMessageTime: serverTimestamp(),
-          updatedAt: serverTimestamp(),
-        }
+        conversationUpdate
       );
-
-      // Update unread counts for other members on the conversation document
-      const conversationDoc = await getDoc(
-        doc(this.db, this.CONVERSATIONS, conversationId)
-      );
-
-      if (conversationDoc.exists()) {
-        const allMembers: string[] = conversationDoc.data()?.members || memberIds;
-        const unreadUpdates: Record<string, unknown> = {};
-        allMembers.forEach((memberId: string) => {
-          if (memberId !== message.senderId) {
-            unreadUpdates[`unRead.${memberId}`] = increment(1);
-          }
-        });
-
-        await updateDoc(
-          doc(this.db, this.CONVERSATIONS, conversationId),
-          {
-            ...unreadUpdates,
-            latestMessage: convertToLatestMessage(`${message.senderId}`, conversationOptions?.name || '', message.text || ''),
-          }
-        );
-      }
+      // Cache so subsequent sends skip the existence check
+      this.knownConversations.add(conversationId);
     } catch (error) {
       console.error('Error sending message:', error);
       throw new Error('Failed to send message');
@@ -335,6 +337,8 @@ export class ChatService {
     return onSnapshot(userConversationsQuery, (snapshot) => {
       const userConversations: ConversationProps[] = [];
       snapshot.forEach((docSnap) => {
+        // Seed existence cache — documents returned by the query definitely exist
+        this.knownConversations.add(docSnap.id);
         const data = docSnap.data();
         const names: Record<string, string> = data.names || {};
         const unreadCounts: Record<string, number> = data.unRead || {};
@@ -343,6 +347,7 @@ export class ChatService {
           name: names[userId] || '',
           members: data.members || [],
           unRead: unreadCounts,
+          typing: data.typing ?? {},
           updatedAt: data.updatedAt?.toMillis?.() ?? data.updatedAt ?? Date.now(),
           joinedAt: data.createdAt?.toMillis?.() ?? data.createdAt ?? Date.now(),
           latestMessage: data.latestMessage || undefined,
@@ -352,44 +357,44 @@ export class ChatService {
     });
   }
 
-  // Update typing status
+  /**
+   * Update typing status on the conversation document itself (matching rn-firebase-chat).
+   * Writing to the conversation doc avoids a dedicated subcollection listener;
+   * typing data flows through the already-active subscribeToUserConversations channel.
+   */
   async updateTypingStatus(conversationId: string, userId: string, isTyping: boolean): Promise<void> {
     try {
-      const conversationRef = doc(this.db, this.CONVERSATIONS, conversationId);
-      const conversationDataRef = collection(conversationRef, 'data');
-      const typingDocRef = doc(conversationDataRef, 'typing');
-
-      await setDoc(typingDocRef, {
-        [`${userId}`]: isTyping,
-        updatedAt: serverTimestamp(),
-      }, { merge: true });
+      await updateDoc(
+        doc(this.db, this.CONVERSATIONS, conversationId),
+        { [`typing.${userId}`]: isTyping }
+      );
     } catch (error) {
       console.error('Error updating typing status:', error);
     }
   }
 
-  // Subscribe to typing status
-  subscribeToTypingStatus(
+  /**
+   * Subscribe to a conversation document for real-time unRead + typing updates.
+   * Matches rn-firebase-chat's userConversationListener.
+   */
+  subscribeToConversation(
     conversationId: string,
-    callback: (typingUsers: Record<string, boolean>) => void
-  ): Unsubscribe {
-    const conversationRef = doc(this.db, this.CONVERSATIONS, conversationId);
-    const typingDocRef = doc(conversationRef, 'data', 'typing');
-
-    return onSnapshot(typingDocRef, (snapshot) => {
-      const data = snapshot.data();
-      const typingUsers: Record<string, boolean> = {};
-
-      if (data) {
-        Object.keys(data).forEach(userId => {
-          if (userId !== 'updatedAt' && data[userId] === true) {
-            typingUsers[userId] = true;
-          }
+    callback: (data: { unRead?: Record<string, number>; typing?: Record<string, boolean> } | undefined) => void
+  ): () => void {
+    return onSnapshot(
+      doc(this.db, this.CONVERSATIONS, conversationId),
+      (snap) => {
+        if (!snap.exists()) {
+          callback(undefined);
+          return;
+        }
+        const data = snap.data();
+        callback({
+          unRead: data?.unRead ?? {},
+          typing: data?.typing ?? {},
         });
       }
-
-      callback(typingUsers);
-    });
+    );
   }
 
   // Update unread count on the main conversation document

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -21,21 +21,6 @@ export class UserService {
   }
 
   /**
-   * Check if a user document exists in Firestore
-   * @param userId - The ID of the user to check
-   * @returns Promise<boolean> - True if user exists, false otherwise
-   */
-  async userExists(userId: string): Promise<boolean> {
-    try {
-      const userDoc = await getDoc(doc(this.db, FireStoreCollection.users, userId));
-      return userDoc.exists();
-    } catch (error) {
-      console.error('Error checking user existence:', error);
-      return false;
-    }
-  }
-
-  /**
    * Create a user document if it doesn't exist
    * @param userId - The ID of the user
    * @param userData - Optional user data to store
@@ -46,16 +31,19 @@ export class UserService {
     userData?: Partial<IUserInfo & Pick<UserProfileProps, 'status'>> & Record<string, unknown>
   ): Promise<void> {
     try {
-      const exists = await this.userExists(userId);
-      if (!exists) {
-        await setDoc(doc(this.db, FireStoreCollection.users, userId), {
+      // setDoc with merge:true creates the document if absent, or merges fields if present.
+      // Avoids the extra getDoc round-trip from the old check-then-write pattern.
+      // updatedAt is always refreshed; createdAt uses merge so it is only written on creation.
+      await setDoc(
+        doc(this.db, FireStoreCollection.users, userId),
+        {
           id: userId,
           createdAt: serverTimestamp(),
           updatedAt: serverTimestamp(),
           ...userData,
-        });
-        console.log(`User document ${userId} created successfully.`);
-      }
+        },
+        { merge: true }
+      );
     } catch (error) {
       console.error('Error creating user document:', error);
       throw new Error('Failed to create user document');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,7 @@ export interface ConversationProps {
   image?: string;
   members: string[];
   unRead?: Record<string, number>;
+  typing?: Record<string, boolean>;
   updatedAt: number;
   joinedAt?: number;
   latestMessage?: LatestMessageProps;
@@ -347,6 +348,11 @@ export interface MessageListProps {
   unReadSeenMessage?: string;
   /** Max messages to display per page; scroll to top loads the previous page */
   maxPageSize?: number;
+  /**
+   * True when other members have unread messages — used to show Sent vs Seen indicator
+   * on the last own message. Matches rn-firebase-chat userUnreadMessage.
+   */
+  userUnreadMessage?: boolean;
 }
 
 export interface MessageInputProps {
@@ -383,6 +389,8 @@ export interface UseChatReturn {
   messages: Message[];
   loading: boolean;
   error: string | null;
+  /** True when other members have unread messages (my last message is "sent" not "seen"). Matches rn-firebase-chat. */
+  userUnreadMessage: boolean;
   sendMessage: (text: string, replyMessage?: ReplyMessagePreview) => Promise<void>;
   updateMessage: (messageId: string, text: string) => Promise<void>;
   deleteMessage: (messageId: string) => Promise<void>;


### PR DESCRIPTION
- Move message display to newest-at-bottom (natural scroll order)
- Fix excessive Firestore channel requests: move typing status from
  subcollection to conversation document, eliminating dedicated
  typing snapshot listener; typing data now flows through the
  already-active subscribeToUserConversations channel
- Auto-mark conversation as read when new messages arrive while
  the user is actively viewing, so unread count never increments
  for an on-screen user
- Hide unread badge immediately on conversation select (optimistic UI)
  before Firestore round-trip completes
- Fix unread badge lookup using String(userId) to handle numeric IDs
- Scroll position restoration when loading older messages (useLayoutEffect)
- Fix Enter key to send message (handleKeyDown had stale handleSend closure
  due to empty deps array); Shift+Enter still inserts a newline